### PR TITLE
Refactor GCS lock library credential and emulator setup

### DIFF
--- a/gcslock/core.py
+++ b/gcslock/core.py
@@ -139,9 +139,6 @@ class GcsLock:
         if lock_owner is None:
             lock_owner = str(uuid.uuid4())
 
-        if credentials is None:
-            credentials, _ = default()
-
         self._bucket = bucket_name
         self._locked_owner = lock_owner
         self._accessor: Accessor = RestAccessor(credentials)

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -1,0 +1,10 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _set_emulator_env():
+    os.environ.setdefault("STORAGE_EMULATOR_HOST", "http://localhost:4443")
+    yield
+    os.environ.pop("STORAGE_EMULATOR_HOST", None)

--- a/tests/unittests/test_core.py
+++ b/tests/unittests/test_core.py
@@ -33,12 +33,6 @@ class TestGcsLock:
         # uuid4 → 固定値
         monkeypatch.setattr("gcslock.core.uuid.uuid4", lambda: self.FIXED_UUID)
 
-        # default credentials → ダミー
-        def fake_credentials():
-            return object(), None
-
-        monkeypatch.setattr("gcslock.core.default", fake_credentials)
-
         # RestAccessor → 単一の MagicMock を返すファクトリ
         accessor = MagicMock()
         accessor.bucket_exists.return_value = True


### PR DESCRIPTION
### Description

This pull request refactors the handling of credentials and emulator setup in the GCS lock library. Specific improvements include:

- Replacing default credential mocking with `AnonymousCredentials` for seamless emulator compatibility.
- Removing the unused `DummyCredentials` implementation.
- Simplifying default credential assignment in `RestAccessor`.
- Introducing a `session`-scoped `_set_emulator_env` pytest fixture for consistent environment setup across tests.

These changes enhance maintainability and ensure consistency when using the emulator in tests.

### Related Issues

_No related issues were mentioned._

### Checklist

- [ ] Tests were added or updated (if applicable).
- [ ] Documentation was updated (if applicable).