### PR TITLE
Add retry mechanism and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,118 @@
 # gcs-atomic-lock
 
-Google Cloud Storage (GCS) object generations and metagenerations are used to implement a lightweight distributed lock with strong, atomic semantics. This library wraps the key conditional operations and provides a simple Python API (context manager) to acquire and release a lock stored as a GCS object.
+**gcs-atomic-lock** is a Python library that uses Google Cloud Storage (GCS) **object generations** and *
+*metagenerations** to implement a lightweight distributed lock with strong, atomic semantics.  
+It wraps GCS’s conditional write APIs and exposes a simple Python context manager for acquiring, updating, and releasing
+a lock.
 
-- Language: Python 3.10
-- Package manager: uv
-- Status: Library + unit tests
-- License: See LICENSE
+- **Language**: Python 3.10+
+- **Package manager**: [uv](https://github.com/astral-sh/uv)
+- **Status**: Library + unit tests
+- **License**: See [LICENSE](./LICENSE)
 
-## Why use this?
+---
 
-- Atomic lock acquisition via GCS conditional writes (`ifGenerationMatch=0`)
-- Lock extension/update using metageneration preconditions (`ifMetagenerationMatch`)
-- Simple Pythonic API (with-context)
-- Pluggable access layer for HTTP/credential handling
-- Helpful exceptions and logging
-- Optional in-memory TTL map to minimize redundant work
+## Features
 
-## How it works (high level)
+- **Atomic lock acquisition**  
+  Uses GCS’s `ifGenerationMatch=0` conditional write to ensure collision-free lock acquisition.
+- **Safe lock updates**  
+  Updates metadata with `ifMetagenerationMatch` to detect changes made by other processes.
 
-1. Check lock object
-   - GET the lock object in the bucket.
-   - If not found → lock appears free (or expired; see metadata).
-   - If found → read `generation`, `metageneration`, `metadata`.
+---
 
-2. Try to acquire (create) the lock
-   - PUT (or upload) with `ifGenerationMatch=0`.
-   - If the object already exists, GCS returns 412 Precondition Failed → lock acquisition fails.
-   - If created (200 OK), you hold the lock.
+## How It Works
 
-3. Update metadata (optional/renew)
-   - PATCH the object with `ifMetagenerationMatch=<current>`.
-   - If someone else updated it in between, 412 is returned → treat as contention.
-   - On success (200 OK) → your lock metadata (e.g., owner, expiry) is updated.
+1. **Check the lock object**
+    - GET the lock object from the bucket.
+    - If not found → lock is free (or expired).
+    - If found → read `generation`, `metageneration`, and `metadata`.
 
-4. Release the lock
-   - DELETE the object to unlock (204 No Content on success).
-   - Optionally validate ownership based on stored metadata before deleting.
+2. **Acquire the lock**
+    - PUT with `ifGenerationMatch=0`.
+    - If the object already exists → **412 Precondition Failed** → acquisition fails.
+    - If created successfully (200 OK) → lock acquired.
+
+3. **Update the lock (optional)**
+    - PATCH with `ifMetagenerationMatch=<current>`.
+    - If another process updated it → **412** → treat as contention.
+    - On success (200 OK) → metadata updated.
+
+4. **Release the lock**
+    - DELETE the object (204 No Content on success).
+    - Optionally verify ownership via stored metadata before deletion.
 
 ## Flow
+
 ```mermaid 
 flowchart
-    A[Start] --> B{GET Bucket} 
-    B -- Not Found --> Z[Bucket Not Found Error] 
-    B -- Found --> C{GET Object} 
-    C -- Not Found --> D[PUT with ifGenerationMatch=0] 
-    D -- 412 --> E[LOCK FAILED] 
-    D -- 200 --> F[LOCK SUCCESS] 
-    C -- Found --> G[PATCH with ifMetagenerationMatch=CurrentValue] 
-    G -- 412 --> E 
-    G -- 200 --> F 
-    F --> H[DELETE Object to Unlock] 
+    A[Start] --> B{GET Bucket}
+    B -- Not Found --> Z[Bucket Not Found Error]
+    B -- Found --> C{GET Object}
+    C -- Not Found --> D[PUT with ifGenerationMatch=0]
+    D -- 412 --> E[LOCK FAILED]
+    D -- 200 --> F[LOCK SUCCESS]
+    C -- Found --> G[PATCH with ifMetagenerationMatch=CurrentValue]
+    G -- 412 --> E
+    G -- 200 --> F
+    F --> H[DELETE Object to Unlock]
     H -- 204 --> I[LOCK RELEASED]
 ```
 
 ## Installation
+
 ```shell
 pip install gcslock
 ```
 
 ## Example
+
+### Authentication Requirement
+Before running the example below, make sure you have authenticated with Google Cloud. You can either:
+
+* Run
+    ```shell
+    gcloud auth application-default login
+    ```
+* **Or** create a Credentials instance using a Service Account key JSON file.
+
+Without authentication, the library will not be able to access GCS.
+
+
+### Code Example
 ```python
 from gcslock import GcsLock, LockState
 from gcslock.exception import GcsLockError
+from google.oauth2.service_account import Credentials
+
+# Optional: Authenticate with Google Cloud Service Account key JSON file
+#cred = Credentials.from_service_account_file("path/to/service_account.json")
 
 BUCKET = "your-bucket-name"
 OBJECT = "locks/my-resource.lock"
 OWNER = "your-owner-id"
 LOCK_EXPIRES_SEC = 60
 
-lock = GcsLock(BUCKET, OBJECT, lock_owner=OWNER)
+lock = GcsLock(
+    bucket_name=BUCKET,
+    lock_owner=OWNER
+)
 
 try:
-    with lock.acquire(lock_id=OBJECT, expires_seconds=LOCK_EXPIRES_SEC) as lock:
+    with lock.acquire(
+            lock_id=OBJECT,
+            expires_seconds=LOCK_EXPIRES_SEC
+    ) as lock:
         # Critical section
         ...
 except GcsLockError as e:
-    print(f"Lock error: {e}")
+    print(
+        f"Lock error: {e}"
+    )
 ```
+
+## Use Cases
+
+* Preventing concurrent execution in distributed job schedulers
+* Coordinating resource access across multiple instances
+* Building a lightweight distributed locking mechanism using GCS


### PR DESCRIPTION
- Introduced a retry mechanism for lock acquisition with a configurable timeout (`max_wait_seconds` parameter). This ensures the lock can be retried until release or timeout, improving functionality.
- Updated unit and integration tests to validate retries, timeouts, and input constraints (`max_wait_seconds`, `expires_seconds`).
- Improved debug logging for traceability during retries.
- Revised README to include more detailed usage instructions, described features, and expanded code examples with authentication guidance.
- Enhanced formatting and content clarity in the documentation for better readability and usability.