### PR TITLE
Add CLI support for GcsLock and relax version constraints

### DIFF
--- a/gcslock/_cli.py
+++ b/gcslock/_cli.py
@@ -1,0 +1,75 @@
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+
+from google.oauth2 import service_account
+
+from gcslock import GcsLock
+
+
+@dataclass(frozen=True)
+class CliArgs:
+    bucket: str
+    object_key: str
+    expires_sec: int
+    wait_sec: int
+    command: list[str]
+    owner: str | None = None
+    service_account_json: str | None = None
+
+
+def parse_args(argv: list[str] | None = None) -> CliArgs:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--bucket", "-b", required=True, help="The GCS bucket name.")
+    parser.add_argument("--object-key", "-k", required=True, help="The object key.")
+    parser.add_argument(
+        "--expires-sec", "-e", type=int, default=20, help="The lock expiration time."
+    )
+    parser.add_argument("--owner", "-o", required=False, help="The lock owner.")
+    parser.add_argument("--wait-sec", "-w", type=int, default=0, help="Lock wait time.")
+    parser.add_argument(
+        "--service-account-json", required=False, help="The service account json."
+    )
+    parser.add_argument(
+        "command",
+        nargs="+",
+        help="The command to execute.",
+    )
+
+    args = parser.parse_args(argv)
+    return CliArgs(**vars(args))
+
+
+def main(argv: list[str] | None = None):
+    try:
+        cli_args = parse_args(argv)
+
+        credentials = None
+        if cli_args.service_account_json is not None:
+            credentials = service_account.Credentials.from_service_account_file(
+                cli_args.service_account_json
+            )
+
+        lock = GcsLock(lock_owner=cli_args.owner, credentials=credentials)
+
+        try:
+            with lock.acquire(
+                cli_args.bucket,
+                cli_args.object_key,
+                cli_args.expires_sec,
+                max_wait_seconds=cli_args.wait_sec,
+            ):
+                subprocess.run(cli_args.command)
+
+        except Exception as e:
+            print(e, file=sys.stderr)
+            sys.exit(1)
+
+    except Exception as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ markers = [
     "unittest: marks unit tests",
 ]
 
-
 [tool.isort]
 profile = 'black'
 multi_line_output = 3
+
+[project.scripts]
+gcslock = "gcslock._cli:main"

--- a/tests/unittests/test__cli.py
+++ b/tests/unittests/test__cli.py
@@ -1,0 +1,228 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gcslock import _cli
+
+
+@pytest.fixture(autouse=True)
+def mock_gcs(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr(_cli, "GcsLock", mock)
+    yield mock
+
+
+@pytest.fixture(autouse=True)
+def mock_process(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr(_cli, "subprocess", mock)
+    yield mock
+
+
+class TestParseArgs:
+    def test_parse_args_all(self):
+        args = _cli.parse_args(
+            [
+                "--bucket",
+                "bkt",
+                "--object-key",
+                "obj",
+                "--expires-sec",
+                "30",
+                "--owner",
+                "owner",
+                "--wait-sec",
+                "5",
+                "--service-account-json",
+                "/tmp/service_account.json",
+                "echo",
+                "hello",
+            ]
+        )
+        assert args.bucket == "bkt"
+        assert args.object_key == "obj"
+        assert args.expires_sec == 30
+        assert args.owner == "owner"
+        assert args.wait_sec == 5
+        assert args.service_account_json == "/tmp/service_account.json"
+        assert args.command == ["echo", "hello"]
+
+    def test_parse_args_short(self):
+        args = _cli.parse_args(
+            [
+                "-b",
+                "bkt",
+                "-k",
+                "obj",
+                "-e",
+                "30",
+                "-o",
+                "owner",
+                "-w",
+                "5",
+                "--service-account-json",
+                "/tmp/service_account.json",
+                "echo",
+                "hello",
+            ]
+        )
+        assert args.bucket == "bkt"
+        assert args.object_key == "obj"
+        assert args.expires_sec == 30
+        assert args.owner == "owner"
+        assert args.wait_sec == 5
+        assert args.service_account_json == "/tmp/service_account.json"
+        assert args.command == ["echo", "hello"]
+
+    def test_parse_args_minimal(self):
+        args = _cli.parse_args(
+            [
+                "--bucket",
+                "bkt",
+                "--object-key",
+                "obj",
+                "echo",
+                "hello",
+            ]
+        )
+        assert args.bucket == "bkt"
+        assert args.object_key == "obj"
+        assert args.expires_sec == 20
+        assert args.owner is None
+        assert args.wait_sec == 0
+        assert args.service_account_json is None
+        assert args.command == ["echo", "hello"]
+
+    def test_parse_args_bucket_not_specific(self):
+        with pytest.raises(SystemExit):
+            _cli.parse_args(
+                [
+                    "--object-key",
+                    "obj",
+                    "echo",
+                    "hello",
+                ]
+            )
+
+    def test_parse_args_object_not_specific(self):
+        with pytest.raises(SystemExit):
+            _cli.parse_args(
+                [
+                    "--bucket",
+                    "bkt",
+                    "echo",
+                    "hello",
+                ]
+            )
+
+    def test_parse_args_command_not_specific(self):
+        with pytest.raises(SystemExit):
+            _cli.parse_args(
+                [
+                    "--bucket",
+                    "bkt",
+                    "--object-key",
+                    "obj",
+                ]
+            )
+
+    def test_parse_args_expires_sec_invalid_type(self):
+        with pytest.raises(SystemExit):
+            _cli.parse_args(
+                [
+                    "--bucket",
+                    "bkt",
+                    "--object-key",
+                    "obj",
+                    "--expires-sec",
+                    "a",
+                    "echo",
+                    "hello",
+                ]
+            )
+
+    def test_parse_args_wait_sec_invalid_type(self):
+        with pytest.raises(SystemExit):
+            _cli.parse_args(
+                [
+                    "--bucket",
+                    "bkt",
+                    "--object-key",
+                    "obj",
+                    "--wait-sec",
+                    "a",
+                    "echo",
+                    "hello",
+                ]
+            )
+
+
+class TestMain:
+    def test_main_success_with_service_account(
+        self, mock_gcs, mock_process, monkeypatch
+    ):
+        creds = MagicMock(name="Credentials")
+        monkeypatch.setattr(
+            _cli.service_account.Credentials,
+            "from_service_account_file",
+            MagicMock(return_value=creds),
+        )
+
+        lock_instance = mock_gcs.return_value
+        ctx = MagicMock()
+        ctx.__enter__.return_value = None
+        lock_instance.acquire.return_value = ctx
+
+        argv = [
+            "--bucket",
+            "bkt",
+            "--object-key",
+            "obj",
+            "--expires-sec",
+            "30",
+            "--owner",
+            "owner",
+            "--wait-sec",
+            "5",
+            "--service-account-json",
+            "/tmp/service_account.json",
+            "echo",
+            "hello",
+        ]
+
+        _cli.main(argv)
+
+        _cli.service_account.Credentials.from_service_account_file.assert_called_once_with(
+            "/tmp/service_account.json"
+        )
+        mock_gcs.assert_called_once_with(lock_owner="owner", credentials=creds)
+        lock_instance.acquire.assert_called_once_with(
+            "bkt", "obj", 30, max_wait_seconds=5
+        )
+        mock_process.run.assert_called_once_with(["echo", "hello"])
+
+    def test_main_error_exit_when_acquire_fails(self, mock_gcs, capsys):
+        lock_instance = mock_gcs.return_value
+        ctx = MagicMock()
+        ctx.__enter__.side_effect = Exception("failed to acquire")
+        lock_instance.acquire.return_value = ctx
+
+        with pytest.raises(SystemExit) as e:
+            _cli.main(
+                [
+                    "--bucket",
+                    "bkt",
+                    "--object-key",
+                    "obj",
+                    "echo",
+                    "world",
+                ]
+            )
+
+        assert e.value.code == 1
+        err = capsys.readouterr().err
+        assert "failed to acquire" in err
+        mock_gcs.assert_called_once_with(lock_owner=None, credentials=None)
+        lock_instance.acquire.assert_called_once_with(
+            "bkt", "obj", 20, max_wait_seconds=0
+        )


### PR DESCRIPTION
### Summary of Changes
- Implement CLI support for `GcsLock` operations by introducing `_cli.py` with argument parsing and command execution functionalities.
- Add a `main` entry point to facilitate command execution from the CLI.
- Register the `gcslock` script in `pyproject.toml` to enable easy CLI usage.
- Include unit tests to ensure reliability of argument parsing and `main` method logic.
- Update `pyproject.toml` to relax version constraints for dependencies: `google-auth` and `requests`.

### Checklist
- [ ] Ensure backward compatibility with existing functionality.
- [ ] Verify the proper working of CLI commands with different argument combinations.
- [ ] Review unit tests for comprehensive coverage and validation.